### PR TITLE
Properly handle adding media when disk is not local

### DIFF
--- a/packages/admin/src/Http/Livewire/Traits/HasImages.php
+++ b/packages/admin/src/Http/Livewire/Traits/HasImages.php
@@ -216,8 +216,17 @@ trait HasImages
                     $file = TemporaryUploadedFile::createFromLivewire(
                         $image['filename']
                     );
-                    $media = $owner->addMedia($file->getRealPath())
-                        ->toMediaCollection('images');
+                    
+                    $media_libary_disk = config("media-library.disk_name");
+                    $media_libary_driver = Storage::disk($media_libary_disk)->getConfig()['driver'];
+
+                    if($media_libary_driver == "local") {
+                        $media = $owner->addMedia($file->getRealPath())
+                                    ->toMediaCollection('images');
+                    } else {
+                        $media = $owner->addMediaFromDisk($file->getRealPath())
+                                    ->toMediaCollection('images');
+                    }
 
                     activity()
                     ->performedOn($owner)


### PR DESCRIPTION
In order to obtain the media from a remote location,`addMediaFromDisk` has to be used.`addMedia` only works when the file is stored on the server. You can set a default media disk for Spatie Media Library, so I used that config and then determined if it was local or not, so the image can be found and added properly.